### PR TITLE
Fab p/fix download edit mode

### DIFF
--- a/modules/common/src/attachments/attachmentSections.component.ts
+++ b/modules/common/src/attachments/attachmentSections.component.ts
@@ -1,5 +1,6 @@
+import { Subscription } from 'rxjs';
 import { CommonModule } from '@angular/common';
-import { Component, EventEmitter, Input, Output, inject } from '@angular/core';
+import { Component, EventEmitter, OnInit, Input, Output, inject } from '@angular/core';
 import {
   ModalController,
   AlertController,
@@ -21,6 +22,7 @@ import { IDEATranslatePipe } from '../translations/translate.pipe';
 import { IDEALocalizedLabelPipe } from '../translations/label.pipe';
 import { IDEAMessageService } from '../message.service';
 import { IDEATranslationsService } from '../translations/translations.service';
+import { IDEAAttachmentsService } from './attachments.service';
 
 @Component({
   selector: 'idea-attachment-sections',
@@ -118,11 +120,12 @@ import { IDEATranslationsService } from '../translations/translations.service';
     }
   `
 })
-export class IDEAAttachmentSectionsComponent {
+export class IDEAAttachmentSectionsComponent implements OnInit {
   private _modal = inject(ModalController);
   private _alert = inject(AlertController);
   private _message = inject(IDEAMessageService);
   private _translate = inject(IDEATranslationsService);
+  private _attachments = inject(IDEAAttachmentsService);
 
   /**
    * The attachment sections to display and manage.
@@ -156,6 +159,14 @@ export class IDEAAttachmentSectionsComponent {
    * Trigger to download a file by URL.
    */
   @Output() download = new EventEmitter<string>();
+
+  protected downloadInEditModeSub: Subscription;
+
+  ngOnInit(): void {
+    this.downloadInEditModeSub = this._attachments.downloadInEditMode.subscribe(url => {
+      this.download.emit(url);
+    });
+  }
 
   reorderSectionsLegend(ev: any): void {
     this.attachmentSections.sectionsLegend = ev.detail.complete(this.attachmentSections.sectionsLegend);

--- a/modules/common/src/attachments/attachments.service.ts
+++ b/modules/common/src/attachments/attachments.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { EventEmitter, Output, inject, Injectable } from '@angular/core';
 import { Attachment } from 'idea-toolbox';
 
 import { IDEAEnvironment } from '../../environment';
@@ -8,6 +8,11 @@ import { IDEAApiService } from '../api.service';
 export class IDEAAttachmentsService {
   protected _env = inject(IDEAEnvironment);
   protected _api = inject(IDEAApiService);
+
+  /**
+   * Trigger to download a file by URL when in edit mode.
+   */
+  @Output() downloadInEditMode = new EventEmitter<string>();
 
   /**
    * Upload a new attachment related to an entity and return the `attachmentId`.

--- a/modules/common/src/attachments/manageAttachmentsSection.component.ts
+++ b/modules/common/src/attachments/manageAttachmentsSection.component.ts
@@ -25,6 +25,7 @@ import { IDEAAttachmentsComponent } from './attachments.component';
 import { IDEATranslatePipe } from '../translations/translate.pipe';
 import { IDEALocalizedLabelPipe } from '../translations/label.pipe';
 import { IDEATranslationsService } from '../translations/translations.service';
+import { IDEAAttachmentsService } from './attachments.service';
 
 @Component({
   selector: 'idea-attachments-section',
@@ -120,7 +121,7 @@ import { IDEATranslationsService } from '../translations/translations.service';
           [multiple]="multiple"
           [color]="color"
           [disabled]="false"
-          (download)="download.emit($event)"
+          (download)="_attachments.downloadInEditMode.emit($event)"
         />
       </ion-list>
     </ion-content>
@@ -129,6 +130,7 @@ import { IDEATranslationsService } from '../translations/translations.service';
 export class IDEAManageAttachmentsSectionComponent implements OnInit {
   private _modal = inject(ModalController);
   private _translate = inject(IDEATranslationsService);
+  _attachments = inject(IDEAAttachmentsService)
 
   /**
    * The attachments section to manage.
@@ -154,10 +156,6 @@ export class IDEAManageAttachmentsSectionComponent implements OnInit {
    * The background color of the component.
    */
   @Input() color: string;
-  /**
-   * Trigger to download a file by URL.
-   */
-  @Output() download = new EventEmitter<string>();
 
   _section: AttachmentSection;
   errors = new Set<string>();


### PR DESCRIPTION
Il problema risiede nel fatto che il componente per gestire la sezione viene aperto all'interno di un modale e l'evento non viene propagato fino alla radice.